### PR TITLE
Add {posargs} in tox.ini.

### DIFF
--- a/pytest-{{cookiecutter.plugin_name}}/tox.ini
+++ b/pytest-{{cookiecutter.plugin_name}}/tox.ini
@@ -3,4 +3,4 @@
 envlist = py27,py33,py34,py35
 [testenv]
 deps=pytest       # install pytest in the venvs
-commands=py.test
+commands=py.test {posargs}


### PR DESCRIPTION
This is pretty useful to do things like `tox -e py35 -- -v` etc.