### PR TITLE
Update .travis.yml for nicer UI, add testing on pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,16 @@
 
 sudo: false
 language: python
-python: 3.5
-env:
-    - TOX_ENV=py27
-    - TOX_ENV=py33
-    - TOX_ENV=py34
-    - TOX_ENV=py35
-
-script: tox -e $TOX_ENV
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 
 install:
-    - pip install tox
+  - pip install tox
+  - "TOX_ENV=${TRAVIS_PYTHON_VERSION/[0-9].[0-9]/py${TRAVIS_PYTHON_VERSION/.}}"
+script: tox -e $TOX_ENV
 
 before_cache:
   - rm -rf $HOME/.cache/pip/log

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "pypy"
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,9 @@ script: tox -e $TOX_ENV
 
 install:
     - pip install tox
+
+before_cache:
+  - rm -rf $HOME/.cache/pip/log
+cache:
+  directories:
+    - $HOME/.cache/pip

--- a/pytest-{{cookiecutter.plugin_name}}/.travis.yml
+++ b/pytest-{{cookiecutter.plugin_name}}/.travis.yml
@@ -2,17 +2,16 @@
 
 sudo: false
 language: python
-python: 3.5
-env:
-    - TOX_ENV=py27
-    - TOX_ENV=py33
-    - TOX_ENV=py34
-    - TOX_ENV=py35
-
-script: tox -e $TOX_ENV
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 
 install:
-    - pip install tox
+  - pip install tox
+  - "TOX_ENV=${TRAVIS_PYTHON_VERSION/[0-9].[0-9]/py${TRAVIS_PYTHON_VERSION/.}}"
+script: tox -e $TOX_ENV
 
 before_cache:
   - rm -rf $HOME/.cache/pip/log

--- a/pytest-{{cookiecutter.plugin_name}}/.travis.yml
+++ b/pytest-{{cookiecutter.plugin_name}}/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "pypy"
 
 install:
   - pip install tox

--- a/pytest-{{cookiecutter.plugin_name}}/.travis.yml
+++ b/pytest-{{cookiecutter.plugin_name}}/.travis.yml
@@ -13,3 +13,9 @@ script: tox -e $TOX_ENV
 
 install:
     - pip install tox
+
+before_cache:
+  - rm -rf $HOME/.cache/pip/log
+cache:
+  directories:
+    - $HOME/.cache/pip

--- a/pytest-{{cookiecutter.plugin_name}}/setup.py
+++ b/pytest-{{cookiecutter.plugin_name}}/setup.py
@@ -35,6 +35,8 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',
         {% if cookiecutter.license == "MIT" -%}
         'License :: OSI Approved :: MIT License',

--- a/pytest-{{cookiecutter.plugin_name}}/tox.ini
+++ b/pytest-{{cookiecutter.plugin_name}}/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.org/en/latest/
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py33,py34,py35,pypy
 
 [testenv]
 deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 recreate = true
 skipsdist = true
-envlist = py27,py33,py34,py35
+envlist = py27,py33,py34,py35,pypy
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Since tox environments are pretty straightforward (just named after the interpreter version), their names can be easily inferred from the `$TRAVIS_PYTHON_VERSION` environmental variable.
Specifying Python version explicitly is more idiomatically correct and makes the UI look nicer (for example, compare presentation of the matrices of [this](https://travis-ci.org/eisensheng/pytest-catchlog/builds/83219389) and [this](https://travis-ci.org/eisensheng/pytest-catchlog/builds/84938478) builds).

Also enable pip caching and testing on pypy.