### PR TITLE
Add "Framework :: Pytest" to list of classifiers

### DIFF
--- a/pytest-{{cookiecutter.plugin_name}}/setup.py
+++ b/pytest-{{cookiecutter.plugin_name}}/setup.py
@@ -26,6 +26,7 @@ setup(
     install_requires=['pytest>={{cookiecutter.pytest_version}}'],
     classifiers=[
         'Development Status :: 4 - Beta',
+        'Framework :: Pytest',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python',


### PR DESCRIPTION
As mentioned recently in the mailing list, PyPI now knows a "Framework :: Pytest" classifier :grin: 