### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,4 +7,4 @@ helps, and credit will always be given.
 
 Please see the [Contributor Guide] to get started.
 
-[Contributor Guide]: http://cookiecutter-pytest-plugin.readthedocs.org/en/latest/contributor-guide/quickstart/ (Contributor Guide)
+[Contributor Guide]: https://cookiecutter-pytest-plugin.readthedocs.io/en/latest/contributor-guide/quickstart/ (Contributor Guide)

--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ Plugin is free and open source software
   [travis_badge]: https://travis-ci.org/pytest-dev/cookiecutter-pytest-plugin.svg?branch=master
   [travis]: https://travis-ci.org/pytest-dev/cookiecutter-pytest-plugin (See Build Status on Travis CI)
   [docs_badge]: https://readthedocs.org/projects/cookiecutter-pytest-plugin/badge/?version=latest
-  [documentation]: http://cookiecutter-pytest-plugin.readthedocs.org/en/latest/ (Documentation)
+  [documentation]: https://cookiecutter-pytest-plugin.readthedocs.io/en/latest/ (Documentation)
   [Cookiecutter]: https://github.com/audreyr/cookiecutter
   [Pytest]: https://github.com/pytest-dev/pytest
   [PyPI]: https://pypi.python.org/pypi
-  [Tox]: https://tox.readthedocs.org/en/latest/
+  [Tox]: https://tox.readthedocs.io/en/latest/
   [Submit a Plugin]: https://pytest.org/latest/contributing.html#submit-a-plugin-co-develop-pytest
   [Pytest Hook Reference]: https://pytest.org/latest/plugins.html#well-specified-hooks
   [MIT license]: http://opensource.org/licenses/MIT

--- a/docs/user-guide/publish-plugin.md
+++ b/docs/user-guide/publish-plugin.md
@@ -38,4 +38,4 @@ Please see the official guidelines at [Submit a Plugin].
   [Submit a Plugin]: https://pytest.org/latest/contributing.html#submit-a-plugin-co-develop-pytest
   [Pytest]: https://github.com/pytest-dev/pytest
   [PyPI]: https://pypi.python.org/pypi
-  [Python Packaging User Guide]: https://python-packaging-user-guide.readthedocs.org/en/latest/distributing.html
+  [Python Packaging User Guide]: https://python-packaging-user-guide.readthedocs.io/en/latest/distributing.html

--- a/pytest-{{cookiecutter.plugin_name}}/README.rst
+++ b/pytest-{{cookiecutter.plugin_name}}/README.rst
@@ -66,6 +66,6 @@ If you encounter any problems, please `file an issue`_ along with a detailed des
 .. _`cookiecutter-pytest-plugin`: https://github.com/pytest-dev/cookiecutter-pytest-plugin
 .. _`file an issue`: https://github.com/{{cookiecutter.github_username}}/pytest-{{cookiecutter.plugin_name}}/issues
 .. _`pytest`: https://github.com/pytest-dev/pytest
-.. _`tox`: https://tox.readthedocs.org/en/latest/
+.. _`tox`: https://tox.readthedocs.io/en/latest/
 .. _`pip`: https://pypi.python.org/pypi/pip/
 .. _`PyPI`: https://pypi.python.org/pypi

--- a/pytest-{{cookiecutter.plugin_name}}/tox.ini
+++ b/pytest-{{cookiecutter.plugin_name}}/tox.ini
@@ -1,4 +1,4 @@
-# For more information about tox, see https://tox.readthedocs.org/en/latest/
+# For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
 envlist = py27,py33,py34,py35,pypy
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.