### PR TITLE
Add MkDocs output directory to .gitignore

### DIFF
--- a/pytest-{{cookiecutter.plugin_name}}/.gitignore
+++ b/pytest-{{cookiecutter.plugin_name}}/.gitignore
@@ -59,6 +59,9 @@ instance/
 # Sphinx documentation
 docs/_build/
 
+# MkDocs documentation
+/site/
+
 # PyBuilder
 target/
 


### PR DESCRIPTION
`mkdocs build` by default outputs to site/, this way the built docs are treated the same way as for Sphinx.