### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     include:
       - python: 2.7
         env: TOX_ENV=py27
-      - python: 3.3
-        env: TOX_ENV=py33
       - python: 3.4
         env: TOX_ENV=py34
       - python: 3.5

--- a/pytest-{{cookiecutter.plugin_name}}/.travis.yml
+++ b/pytest-{{cookiecutter.plugin_name}}/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     include:
       - python: 2.7
         env: TOX_ENV=py27
-      - python: 3.3
-        env: TOX_ENV=py33
       - python: 3.4
         env: TOX_ENV=py34
       - python: 3.5

--- a/pytest-{{cookiecutter.plugin_name}}/appveyor.yml
+++ b/pytest-{{cookiecutter.plugin_name}}/appveyor.yml
@@ -6,9 +6,6 @@ environment:
     - PYTHON: "C:\\Python27"
       TOX_ENV: "py27"
 
-    - PYTHON: "C:\\Python33"
-      TOX_ENV: "py33"
-
     - PYTHON: "C:\\Python34"
       TOX_ENV: "py34"
 

--- a/pytest-{{cookiecutter.plugin_name}}/setup.py
+++ b/pytest-{{cookiecutter.plugin_name}}/setup.py
@@ -23,6 +23,7 @@ setup(
     description='{{cookiecutter.short_description}}',
     long_description=read('README.rst'),
     py_modules=['pytest_{{cookiecutter.module_name}}'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=['pytest>={{cookiecutter.pytest_version}}'],
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -33,7 +34,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/pytest-{{cookiecutter.plugin_name}}/tox.ini
+++ b/pytest-{{cookiecutter.plugin_name}}/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py27,py33,py34,py35,py36,pypy,flake8
+envlist = py27,py34,py35,py36,pypy,flake8
 
 [testenv]
 deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 recreate = true
 skipsdist = true
-envlist = py27,py33,py34,py35,py36,pypy
+envlist = py27,py34,py35,py36,pypy
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
And add `python_requires` to help pip.