### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
         env: TOX_ENV=py35
       - python: 3.6
         env: TOX_ENV=py36
+      - python: 3.7
+        env: TOX_ENV=py37
+        dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
       - python: pypy
         env: TOX_ENV=pypy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Config file for automatic testing at travis-ci.org
 
-sudo: false
 language: python
 
 matrix:


### PR DESCRIPTION
Adds the missing piece from #32

https://docs.travis-ci.com/user/languages/python/#development-releases-support says that Python 3.7 can not be run on Trusty.  Travis support is [confirming that the recommended solution](https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905).  It is not much of a hack if [ipython](https://github.com/ipython/ipython/blob/master/.travis.yml#L68), [jupyter](https://github.com/jupyter/jupyter_server/blob/master/.travis.yml#L69), [numpy](https://github.com/numpy/numpy/blob/master/.travis.yml#L40), [matplotlib](https://github.com/matplotlib/matplotlib/blob/master/.travis.yml#L3) are all relying on it.

[Travis are now recommending removing __sudo__](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)