### PR TITLE
drop deprecated sudo:false from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Config file for automatic testing at travis-ci.org
 
-sudo: false
 language: python
 
 matrix:


### PR DESCRIPTION
TravisCI have started ignoring sudo:false and moved linux builds from container infrastructure to VMs.
According to their announcement, this change already went in to effect on 07/Dec/2018

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration