### PR TITLE
Use "GNU GPL v3.0+" instead of "GNU GPL v3.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Choose from 1, 2, 3 [1]: 1
 Select license:
 1 - MIT
 2 - BSD-3
-3 - GNU GPL v3.0
+3 - GNU GPL v3.0+
 Choose from 1, 2, 3 [1]: 2
 INFO:post_gen_project:Moving files for mkdocs.
 ```
@@ -73,7 +73,7 @@ pytest-awesome/
 - Continuous integration configuration for [Travis CI] and [AppVeyor]
 - Optional documentation with either [Sphinx] or [MkDocs]
 - Choose from several licenses, such as [MIT], [BSD-3], [Apache v2.0], [GNU GPL
-  v3.0], or [MPL v2.0]
+  v3.0+], or [MPL v2.0]
 
 ## Requirements to Submit a Plugin
 
@@ -141,7 +141,7 @@ Plugin is free and open source software.
   [MIT]: http://opensource.org/licenses/MIT
   [MPL v2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt
   [BSD-3]: http://opensource.org/licenses/BSD-3-Clause
-  [GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt
+  [GNU GPL v3.0+]: http://www.gnu.org/licenses/gpl-3.0.txt
   [Apache v2.0]: http://www.apache.org/licenses/LICENSE-2.0
   [Travis CI]: https://travis-ci.com/
   [AppVeyor]: http://www.appveyor.com/

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -15,7 +15,7 @@
     "license": [
         "MIT",
         "BSD-3",
-        "GNU GPL v3.0",
+        "GNU GPL v3.0+",
         "Apache Software License 2.0",
         "Mozilla Public License 2.0"
     ]

--- a/pytest-{{cookiecutter.plugin_name}}/LICENSE
+++ b/pytest-{{cookiecutter.plugin_name}}/LICENSE
@@ -2,7 +2,7 @@
 {%- include 'licenses/MIT' %}
 {%- elif cookiecutter.license == "BSD-3" -%}
 {%- include 'licenses/BSD-3' %}
-{%- elif cookiecutter.license == "GNU GPL v3.0" -%}
+{%- elif cookiecutter.license == "GNU GPL v3.0+" -%}
 {%- include 'licenses/GPL-3' %}
 {%- elif cookiecutter.license == "Apache Software License 2.0" -%}
 {%- include 'licenses/Apache-2' %}

--- a/pytest-{{cookiecutter.plugin_name}}/setup.py
+++ b/pytest-{{cookiecutter.plugin_name}}/setup.py
@@ -44,8 +44,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         {%- elif cookiecutter.license == "BSD-3" -%}
         'License :: OSI Approved :: BSD License',
-        {%- elif cookiecutter.license == "GNU GPL v3.0" -%}
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        {%- elif cookiecutter.license == "GNU GPL v3.0+" -%}
+        'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         {%- elif cookiecutter.license == "Apache Software License 2.0" -%}
         'License :: OSI Approved :: Apache Software License',
         {%- elif cookiecutter.license == "Mozilla Public License 2.0" -%}


### PR DESCRIPTION
Free Software Foundation (the steward of the GNU GPL family
licenses) encourages using gplvX+ instead of gplvX-only licensing. For
example:

> ... This is why it is important to release under "GPL version N or later"
> -- so that we can fix such problems for them, even when they have many
> copyright holders.

https://www.fsf.org/licensing/zfs-and-linux .

See also the notes in https://spdx.org/licenses/GPL-3.0-or-later.html