### PR TITLE
fix: use plugin name for pytest plugin name in pyproject.toml

### DIFF
--- a/pytest-{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/pytest-{{cookiecutter.plugin_name}}/pyproject.toml
@@ -50,4 +50,4 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/{{cookiecutter.github_username}}/pytest-{{cookiecutter.plugin_name}}"
 [project.entry-points.pytest11]
-django = "pytest_{{cookiecutter.module_name}}.plugin"
+{{cookiecutter.plugin_name}} = "pytest_{{cookiecutter.module_name}}.plugin"


### PR DESCRIPTION
This doesn't seem to be read by pytest (tested with pytest 8.1.1) but it seemed odd that the plugin name generated was hard-coded to `django` instead of using the provided `{{cookiecutter.plugin_name}}`.